### PR TITLE
add jekyll-paginate and redcarpet gems to dev instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This website is built with [Jekyll](http://jekyllrb.com/).
 Development
 -----------
 
- 1. `gem install jekyll jekyll-redirect-from`
+ 1. `gem install jekyll jekyll-redirect-from jekyll-paginate redcarpet`
  2. `jekyll serve --watch`
  3. start editing files
 


### PR DESCRIPTION
just did a dev setup from scratch and needed to install these gems as well before the site would serve. on Ruby 2.1.2 fyi.
