### PR TITLE
Add posts from 2005-2007 site

### DIFF
--- a/_posts/2005-09-19-san-now-available-to-the-public.md
+++ b/_posts/2005-09-19-san-now-available-to-the-public.md
@@ -1,0 +1,7 @@
+---
+title: SAN now available to the public
+layout: post
+---
+The Storage Area Network is now available for access to all. Its address is [http://san.csc.calpoly.edu](http://san.csc.calpoly.edu). The SAN contains valuable Debian, Gentoo, Ubuntu and Linux kernel resources, available for use in apt-get, portage, and other regular uses. Congratulations to red0x and cappaberra on their work building and maintaining the SAN!
+
+

--- a/_posts/2005-12-05-cplug-shirt-of-the-year.md
+++ b/_posts/2005-12-05-cplug-shirt-of-the-year.md
@@ -1,0 +1,21 @@
+---
+title: CPLUG Shirt of the Year
+layout: post
+---
+Ladies and gentlemen....
+ THERE IS A WINNER!
+ 
+ This decision was a long and hard one, but after a stamina-draining session of, um, head banging, we have come to a climatic end.
+ 
+ If you haven't figured it out yet, the winner is : The Pill!
+  
+  
+ ![](http://www.cplug.org/shirts/red.png)  
+  
+
+ 
+ For those of you interesting in purchasing a t-shirt and supporting the CPLUG, please e-mail your request to execboard at cplug dot org . Prices will be announced once we have the total number of orders, but it should be pretty reasonable.
+ 
+ Any questions can also be directed to execboard at cplug dotorg in regards to the t-shirts.
+
+

--- a/_posts/2006-04-27-2006-2007-cplug-officer-elections.md
+++ b/_posts/2006-04-27-2006-2007-cplug-officer-elections.md
@@ -1,0 +1,222 @@
+---
+title: 2006 - 2007 CPLUG Officer Elections
+layout: post
+---
+It's time to get in your votes for next year's CPLUG Executive Board. Which of these fine young nominees will steer the Linux Users Group for
+ the next school year?
+  
+  
+
+ Send your votes in to [EXECBOARD at CPLUG dot ORG](mailto:execboard@cplug.org) (one vote per position) by
+ 11:59:59 PM, Wednesday, May 3rd to be counted.
+  
+  
+
+ **Red Wagner (redson): President**
+  
+  
+
+ As it has been suggested that each of us launch promotional material to
+ endorse ourselves for our positions, and because of the fact that my
+ attempt at running for President last year was thwarted by a spam
+ filter, I give you my candidacy plea from a year ago (It's slightly
+ different than what I would have written now, as I didn't know most of
+ you that well. and I modified it a bit...) :
+  
+  
+
+ ------------begin original------------------------------------- 
+  
+  
+
+ Some would point out that I am not very qualified as I have "not been"
+ to a CPLUG meeting, but I believe this to be a vile lie and a moot
+ point. First of all, as I have been absent from Cal Poly for two years,
+ it would have been hard for me to be a member in previous years, but
+ during this time I did attend the UCLALUG as well as the USCLUG, so I
+ have very much been involved in the community. Also, most of the CPLUG
+ conversation takes place in #cplug, which I frequent, and I will attend
+ the FYM event on April 16th to meet more of the CPLUG in person and try
+ and recruit new members.
+  
+  
+
+ Lastly, as the current Linux admin for the Cisco Networking lab, I'll
+ always be able to unlock the door for meetings. ;-) 
+  
+  
+
+ -----------------end original---------------------------------
+  
+  
+
+ **Derek Lockhart (TheDiff): Vice President, President**
+  
+  
+
+ CPLUG has always been a club of great integrity and prosperity. It has
+ been an icon rising above the sea of mediocre Cal Poly clubs, a
+ benchmark by which other clubs judge themselves. As Vice President of
+ CPLUG, I intend to uphold the great tradition of past CPLUG execboards,
+ as well as guide this great and righteous organization towards continued
+ success. (APPLAUSE)
+  
+  
+
+ But my vision for CPLUG extends beyond the continued propagation of the
+ clubs lineage; rather I hope to expand the contribution of the club in
+ both the campus and San Luis Obispo communities. (APPLAUSE) I, in
+ cooperation with the rest of the CPLUG board, hope to improve both the
+ quality and quantity of events which CPLUG hosts, as well as increase
+ the utility of said events to the community and the club.
+  
+  
+
+ Most importantly, as a club which promotes open source software, CPLUG
+ serves an important role as an informational and assistive resource to
+ those who are not familiar with Linux and the software which runs on it.
+ However, there are some other software development ideologies that hate
+ our concept of freedom, and would do anything to attack it. These
+ individuals are freedom haters, extremists, and probably even
+ terrorists. We must do more to defend ourselves against threats to our
+ freedom, and to protect our way of life. (APPLAUSE) I urge you all to
+ support my candidacy and my hope to create a CPLUG Department of OS
+ Security. It is the only way we can defend ourselves against the
+ surrounding hordes of defective, unusable, and dirty proprietary
+ software. 
+  
+  
+
+ We wage a war to save civilization itself. We did not seek it, but we
+ will fight it and we will prevail. (APPLAUSE)
+  
+  
+
+ My fellow CPLUGers, let's Roll.
+ (APPLAUSE)
+  
+  
+**Keith McCabe (kmccabe): Vice President**  
+  
+
+ I've been idling in IRC for a while and apparently got nominated
+ (that'll teach me to show up to meetings). Some people tell me I am
+ responsible, but I'm not sure I believe them. I'm one of those people
+ who lists "Linux" as a hobby, probably because I keep finding myself
+ installing Gentoo. My other hobbies consist of coding and satellites.
+ I'm primarily throwing my name in the ring because I'll be here next
+ year, and really think the LUG is a good group of people. (Shameless
+ flattery gets me votes, right?)
+  
+  
+
+ **Rohen Peterson (Ozymandius): Secretary**
+  
+  
+
+ I'm running for the 2006-2007 position of CPLUG Secretary.
+  
+  
+
+ The role of secretary includes moderating the mail-lists, recording the
+ events of the meetings, posting news, and other administrative issues.
+ The secretary is also the person that stops the 9 billion spam messages
+ from hitting your personal box. I am very active in the LUG (and am
+ the current Secretary) and most news is posted as soon as I get
+ confirmation from the officers, as I live on IRC.
+  
+  
+
+ I'm a 3rd year CPE and 2nd year member (because Travis wouldn't let me
+ pay dues and join the first time in Spring 04). I use Gentoo Linux, and
+ have used Ubuntu, RedHat, Fedora, SuSe, and Mandrake. I also use VIM.
+  
+  
+
+ My goal for the LUG is to expand the advertising to encompass more than
+ just the EE/CSC buildings. I would like to set up advanced planning so
+ that we can start posting Campus Wide Announcements on the My CalPoly
+ frontpage.
+  
+  
+
+ PS - Join The Committee to Re-Elect the Present Secretary (CREEPS)
+ campaign!
+  
+  
+
+ **David Sharp (whereami): Treasurer**
+  
+  
+
+ Next year, I will be a Senior majoring in Computer Enigeering. I have
+ learned a lot about Linux over the past three years, and love
+ spreading the good news. Gentoo is my distro of choice, so you know
+ I'm hard core! (maybe.) I have been a member of CPLUG since I
+ discovered it my freshman year, but haven't done a lot for the club
+ other than helping people in the channel. So, now I want to help the
+ club grow and spread the cause of Linux. F{ree,ix}YM are great, but I
+ think we can do more to get our name out there. If that means buying a
+ penguin suit and coercing professors or members into mildly
+ embarassing but extremely hilarious and, more importantly, highly
+ visible situations, then that's where the money needs to go. Pizza is
+ always good too.
+  
+  
+
+ **Garret Garcia (ggarcia): Treasurer**
+  
+  
+
+ First of all, I'm honored to be included among the nominees. 
+  
+  
+
+ I'm a CSC. This is my third year at Poly, and I have two more to go. I'm eager to become more active within CPLUG and serving as Treasurer seems like a good way of getting involved. As for qualifications... I was the Treasurer of my Junior High School in eighth grade, and also my freshman year of high school. My skills may be a little rusty, but I am confident that my knowledge of the fine art of Treasuring will return to me with little trouble. If I am elected, the CPLUG will enter a new era of wealth and prosperity that previously could only be attained by slightly larger Linux User Groups!
+  
+  
+
+ In all seriousness, I believe that I would do a good job as Treasurer. This club has great potential both as a resource to new Linux users and as an encouragement for those who have yet to cross over to do so. Win or lose, I'm glad to be a part of it. In conclusion: I like Linux. I like the CPLUG. And I like money. Your votes will be appreciated.
+  
+  
+
+ P.S. Here is a picture of what my reaction may look like if I win: http://www.famousplagiarists.com/images/leskomatthew.jpg
+  
+  
+
+ **Jimson Xu: President, Treasurer**
+  
+  
+
+ I don't know anything about being treasurer. But I am generally good
+ with
+ money. Those things go together right? So vote me for treasurer! I'm
+ not 
+ aiming for president, but if I somehow win that position by satan's
+ touch, I 
+ will still accept it...if that's what the votes say. But my vote for 
+ president is for Red! Go Red!
+  
+  
+
+ **SUMMARY OF CANDIDATES
+  
+  
+
+ President: Red (redson)
+  
+
+ Vice President: Keith (kmccabe), Derek (TheDiff)
+  
+
+ Secretary: Seth (superseth), Rohen (Ozymandius)
+  
+
+ Treasurer: Garret (ggarcia), David (whereami)**
+  
+    
+  
+
+ Please vote buy sending at e-mail to the [EXECBOARD at CPLUG dot ORG](mailto:execboard@cplug.org).
+
+

--- a/_posts/2006-07-30-election-results.md
+++ b/_posts/2006-07-30-election-results.md
@@ -1,0 +1,15 @@
+---
+title: Election Results
+layout: post
+---
+As you [may already know](http://lists.cplug.org/pipermail/cplug/2006-May/000440.html), elections for the 06-07 execboard have been completed and are as follows.
+
+- President: Red
+- VP: Derek
+- Secretary: Seth / Rohen
+- Treas: David Sharp
+- Master of What's Going On: Jimson
+- Web: Keith McCabe
+
+ 
+ Congratulations to the new execboard.

--- a/_posts/2006-10-01-fym-registration-open.md
+++ b/_posts/2006-10-01-fym-registration-open.md
@@ -1,0 +1,7 @@
+---
+title: FYM Registration Open
+layout: post
+---
+Go ahead and register for the upcoming FYM right [here!](fym-reg.html) Pre-registration is not required but highly encouraged, and will help us better serve you!
+
+

--- a/_posts/2006-10-03-ruby-resources.md
+++ b/_posts/2006-10-03-ruby-resources.md
@@ -1,0 +1,17 @@
+---
+title: Ruby Resources
+layout: post
+---
+Thanks to all who attended the Ruby talk--we had a great turnout for an excellent talk, despite the technical difficulties.
+
+More material from the presentation is coming, but in the meantime, here are some of the Ruby links given out near the end of the talk.
+
+ [Ruby User's Guide](http://www.rubyist.net/~slagell/ruby/)  
+ [why's (poignant) guide to Ruby](http://qa.poignantguide.net/
+)  
+ [Programming Ruby: The Pragmatic Programmer's Guide](http://www.ruby-doc.org/docs/ProgrammingRuby/)  
+ [Ruby Quiz](http://rubyquiz.com/)  
+
+Edit: Bonus! Lucas' slides are now online in [pdf](realrubytalk.pdf) and [odp](realrubytalk.odp) format!
+
+

--- a/_posts/2006-10-05-video-of-the-ruby-talk.md
+++ b/_posts/2006-10-05-video-of-the-ruby-talk.md
@@ -1,0 +1,9 @@
+---
+title: Video of the Ruby Talk
+layout: post
+---
+Video of the Ruby Talk is now online! Get it [here](http://share.cplug.org/CPLUG-RubyTalk-CustomFlix.mp4). (h.264 with AAC Audio, 165 MB, 1:05). Right-click, save as.
+
+mplayer is recommended to play the file--just make sure you have the necessary libs installed (x264 and faad2, which should have packages under most major distros).
+
+

--- a/_posts/2007-01-18-scheme-resources.md
+++ b/_posts/2007-01-18-scheme-resources.md
@@ -1,0 +1,34 @@
+---
+title: Scheme Resources
+layout: post
+---
+Many thanks to Casey Klein for giving a fun and informative talk on Scheme! In addition to his [slides](schemetalk.pdf), created using [slideshow](http://www.plt-scheme.org/software/slideshow/), here is a list of recommended resources for more infromation on Scheme.
+
+Programming Environment:   
+  
+ [PLT Scheme](http://www.plt-scheme.org)   
+
+ Notes: Package includes both DrScheme IDE and MzScheme command-line interpreter. DrScheme supports a bunch of Scheme dialects (and even some non-Schemes); select the PLT-\>Pretty Big language to get started.
+
+General Resources:   
+  
+ [How to Use Scheme](http://www.htus.org/)  
+  
+ [The Schematics Scheme Cookbook](http://schemecookbook.org)   
+  
+ [The Scheme Programming Language](http://www.scheme.com/tspl3/)   
+  
+ [PLT Scheme Mailing List](http://www.plt-scheme.org/maillist/)
+
+Macro Resources:  
+  
+ [
+ The Swine Before Perl](http://technetcast.ddj.com/tnc_play_stream.html?stream_id=644) (slides and accompanying audio)  
+  
+ [Automata via Macros](http://www.cs.brown.edu/~sk/Publications/Papers/Published/sk-automata-macros/)  
+
+ Notes: Paper is the "extended exposition" of the presentation above.  
+  
+ [Writing Hygienic Macros in Scheme with syntax-case](ftp://ftp.cs.indiana.edu/pub/scheme-repository/doc/pubs/iucstr356.ps.gz)
+
+

--- a/_posts/2007-09-18-welcome-to-the-2007-2008-school-year.md
+++ b/_posts/2007-09-18-welcome-to-the-2007-2008-school-year.md
@@ -1,0 +1,15 @@
+---
+title: Welcome to the 2007/2008 School Year!
+layout: post
+---
+Hello ladies and gentlemen!
+
+Welcome back to school and another year of epic penguin goodness!
+
+If you are a freshman, or just new to unix based operating systems, check out our event on the 20th in the CSC building. Also if you are interested, our famous Free Your Machine (FYM) will be happening in early October, keep your eyes open for more info.
+
+Good luck to all!  
+
+ /Nat and the rest of the execboard
+
+

--- a/_posts/2007-09-20-linux-info-session-recap.md
+++ b/_posts/2007-09-20-linux-info-session-recap.md
@@ -1,0 +1,58 @@
+---
+title: Linux Info Session Recap
+layout: post
+---
+We had a great presentation by Seth tonight. Here are some notes from him and other cplugers on the event:
+
+You can get [the PDF](http://www.csc.calpoly.edu/~vmeyerso/cplug/) from http://www.csc.calpoly.edu/~vmeyerso/cplug/ as well 
+ as the C file from the demo.
+
+**[GCC and JGrasp](http://www.csc.calpoly.edu/~akeen/courses/csc101/references/gcc.html)**
+ http://www.csc.calpoly.edu/~akeen/courses/csc101/references/gcc.html
+
+**[C-Language FAQ](http://c-faq.com/)**
+ http://c-faq.com/
+
+**[GDB Tutorial](http://www.csc.calpoly.edu/~pnico/class/f07/cpe453/lab/gdb/gdb.html)** 
+ http://www.csc.calpoly.edu/~pnico/class/f07/cpe453/lab/gdb/gdb.html
+
+**[Make Tutorial](http://www.csc.calpoly.edu/~pnico/class/f07/cpe453/doc/make.html)**
+ http://www.csc.calpoly.edu/~pnico/class/f07/cpe453/doc/make.html
+
+**Using SSH:**  
+
+ On Windows, SSH is limited to text input. Arrow keys probably wont
+ work, and you cannot easily transfer work to-from your windows machine
+ and hornet/falcon/vogon using it. Copy paste is sketchy too.
+
+Also, the SSH client provided by the school is limited Use PuTTy and 
+ FileZilla (both FOSS) for a better experience overall. PuTTy supports
+ colors and is overall a faster and more efficient experience. FileZilla
+ doesn't crash on a regular basis like the SSH File transfer client does.
+
+PuTTy works exactly like SSH Secure Shell. Enter vogon.csc.calpoly.edu
+ and go.
+
+FileZilla takes a little more configuring. Open a new "site"
+ The type is SFTP/SSH, and the logon type is normal
+ host is vogon.csc.calpoly.edu, port 22
+ Choose to have it remember your password or not, and then hit
+ connect. At this point it works exactly like SSH Secure FTP.
+
+http://www.chiark.greenend.org.uk/~sgtatham/putty/
+ http://filezilla-project.org/
+
+On Linux/Unix/Mac there are much fancier things that can be done with
+ SSH. Come to our Power of Unix talk for info on those advanced functions.
+
+**[GCC on windows:](http://www.csc.calpoly.edu/~akeen/courses/csc101/references/gcc.html)**
+ 
+ http://www.csc.calpoly.edu/~akeen/courses/csc101/references/gcc.html
+   
+
+ Follow instructions on Keen's site. Setting the path may require a
+ reboot to take affect.
+
+That's All folks! Look forward to our FYM Sept. 29th! More details to follow.
+
+


### PR DESCRIPTION
I cobbled together this:

``` ruby
require 'mysql2'
require 'reverse_markdown'

client = Mysql2::Client.new(:host => "localhost", :username => "root",
                            :database => "cplug")
client.query("select * from news").each do |row|
  title = row["name"]
  slug = title.downcase.gsub(/\W+/, ' ').strip.tr(' ', '-')
  filename = "_posts/#{row["date"]}-#{slug}.md"
  body = ReverseMarkdown.convert row["description"]
  body.gsub! /\r\n?/, "\n"
  File.open(filename, "w") do |file|
    file.write <<-END.gsub(/^ {6}/, '')
      ---
      title: #{title}
      layout: post
      ---
      #{body}
    END
  end
end
```

There are some broken links (I think we have copies of some, but not all, of the PDFs and other files from this site) and formatting, but mostly it looks reasonable.

Fixes #14 
