### PR TITLE
ignore .bundle directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site
 .sass-cache/
+.bundle


### PR DESCRIPTION
it's common to use `bundle install --path=.bundle` to install gem to a project-local `.bundle` directory, which should be ignored by git.
